### PR TITLE
Add cache and organize metadata

### DIFF
--- a/src/pinata/pinataClient.js
+++ b/src/pinata/pinataClient.js
@@ -1,17 +1,31 @@
 const pinataSDK = require('@pinata/sdk');
+const { cache } = require('../utils/cache');
 
 const client = {
   pinata: undefined,
-  pinFile: function (sourcePath, name) {
-    const options = {
-      pinataMetadata: {
-        name,
-      },
-      pinataOptions: {
-        cidVersion: 0,
-      },
-    };
-    return this.pinata.pinFromFS(sourcePath, options);
+  pinFile: async function (sourcePath, name, useCache = false) {
+    let cid;
+    if (useCache && cache.has(sourcePath)) {
+      cid = cache.get(sourcePath);
+      console.log(
+        `file ${sourcePath} has been already uploaded, returning cid:${cid} from cache.`
+      );
+      return cid;
+    } else {
+      const options = {
+        pinataMetadata: {
+          name,
+        },
+        pinataOptions: {
+          cidVersion: 0,
+        },
+      };
+      let pinResult = await this.pinata.pinFromFS(sourcePath, options);
+      cid = pinResult?.IpfsHash;
+      cache.set(sourcePath, cid);
+      console.log(`uploaded file ${sourcePath}, cid:${cid}.`);
+    }
+    return cid;
   },
   pinJson: function (json, name) {
     const options = {

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,0 +1,25 @@
+const crypto = require('crypto');
+const cache = {
+  store: new Map(),
+  getHash: function (data) {
+    let hashed = crypto.createHash('MD5').update(data).digest('hex');
+    return hashed;
+  },
+  set: function (key, value) {
+    let keyHash = this.getHash(key);
+    this.store.set(keyHash, value);
+  },
+  has: function (key) {
+    let keyHash = this.getHash(key);
+    return this.store.has(keyHash);
+  },
+  get: function (key) {
+    let keyHash = this.getHash(key);
+    return this.store.get(keyHash);
+  },
+  clear: function () {
+    this.store.clear();
+  },
+};
+
+module.exports = { cache };

--- a/src/utils/cache.test.js
+++ b/src/utils/cache.test.js
@@ -1,0 +1,51 @@
+const { cache } = require('./cache');
+
+describe('cache tests', () => {
+  beforeEach(() => {
+    cache.clear();
+  });
+
+  afterEach(() => {
+    cache.clear();
+  });
+  it('test cache hits', () => {
+    keys = [
+      'nMKmBSS9b06SwibDptXMETV8Sg8ctoSOQcTpNEBleubwPRQz3BhXGsQTRUBE',
+      'DhTA4CNFiHWvam19grpjcSdtAKmjSHrMRAaWHU8xMFxvdKmFXLw16aZCXDX5',
+      'V69hqnl3ZdZU5zAmuy7ZWCfT6zK14pqIbQ6Rna6hyD7tZ2J4hvxTrAsQ2mfy',
+      'WIFdTRgyI5IbvmWOcg1ATKaxvBM2XR1bsDnlSfBBmOQtvOid4KmfuChLgyzQ',
+      'a0SLRWTod5LV10ZocsE3R9BD1QYoCHKQnKLkXsREZP0xyalG2UT9HnMNTHOM',
+      '텙蝢k򈜵텒Q􆄙=󡾰𡄡d򭸣򰱰󜾜Ġ޾򴊫ꨙ؞𱤄wَ뢉񧇆Tܪyڀ쌿b3ꘓળEɕ澟񹼍㎱򔜉6𼴾鑡򤹨Ӥ+k҄',
+      '득׎ֹ쬒Ȫξ󭁓쀞J񤦽쮇㊝]򛇑󲮰yȆل8h󇐈桸󲦌񧝰񫸲𻃲跖Ə͟(󗄀렸B寖Z�򭏂𪂿Έ󷱾օ԰󞴫򖈟b񫑷򜐄',
+      '빽𪔎g̊嵹꭫⅜=좄񞀎񑈭꒻_̎ꀴ+꼺̦⹡󭴶Y�̌񾄀º닾􁢙鉢ӿاщ=򰮍計+򺰻񉳫岍3XၜŢ혏ꙟ󿩸´t򤸤',
+      '�N偮󟪁≄fba򲌂9ȍ񯒴ʝ쩦傌􊹅圛c𼳑1󕸿ׁ⦖κa쵋󈓭ꔻ㢕팲ꕣd񚀯ǶᎵ􁎉Ү󖕬o𠫎򩴍ҿ𾄠򇂗񰡸뽕䫧',
+      "`眚ԧ�𚈂󟇏ҕ3'̔@ೈխ䬮#a爲񥕠ŝm쵀𥆋큢Κr׹뫝ڕ鈼죠6⪔ћ܍򣭔̨߶_󘵲ܺ졤򞏻址⪹k񚙝󨭯󵬐",
+    ];
+
+    keys.forEach((key) => cache.set(key, key));
+    keys.forEach((key) => {
+      expect(cache.get(key)).toBe(key);
+      expect(cache.has(key)).toBe(true);
+    });
+  });
+
+  it('test cache not available', () => {
+    keys = [
+      'nMKmBSS9b06SwibDptXMETV8Sg8ctoSOQcTpNEBleubwPRQz3BhXGsQTRUBE',
+      'DhTA4CNFiHWvam19grpjcSdtAKmjSHrMRAaWHU8xMFxvdKmFXLw16aZCXDX5',
+      'V69hqnl3ZdZU5zAmuy7ZWCfT6zK14pqIbQ6Rna6hyD7tZ2J4hvxTrAsQ2mfy',
+      'WIFdTRgyI5IbvmWOcg1ATKaxvBM2XR1bsDnlSfBBmOQtvOid4KmfuChLgyzQ',
+      'a0SLRWTod5LV10ZocsE3R9BD1QYoCHKQnKLkXsREZP0xyalG2UT9HnMNTHOM',
+      '텙蝢k򈜵텒Q􆄙=󡾰𡄡d򭸣򰱰󜾜Ġ޾򴊫ꨙ؞𱤄wَ뢉񧇆Tܪyڀ쌿b3ꘓળEɕ澟񹼍㎱򔜉6𼴾鑡򤹨Ӥ+k҄',
+      '득׎ֹ쬒Ȫξ󭁓쀞J񤦽쮇㊝]򛇑󲮰yȆل8h󇐈桸󲦌񧝰񫸲𻃲跖Ə͟(󗄀렸B寖Z�򭏂𪂿Έ󷱾օ԰󞴫򖈟b񫑷򜐄',
+      '빽𪔎g̊嵹꭫⅜=좄񞀎񑈭꒻_̎ꀴ+꼺̦⹡󭴶Y�̌񾄀º닾􁢙鉢ӿاщ=򰮍計+򺰻񉳫岍3XၜŢ혏ꙟ󿩸´t򤸤',
+      '�N偮󟪁≄fba򲌂9ȍ񯒴ʝ쩦傌􊹅圛c𼳑1󕸿ׁ⦖κa쵋󈓭ꔻ㢕팲ꕣd񚀯ǶᎵ􁎉Ү󖕬o𠫎򩴍ҿ𾄠򇂗񰡸뽕䫧',
+      "`眚ԧ�𚈂󟇏ҕ3'̔@ೈխ䬮#a爲񥕠ŝm쵀𥆋큢Κr׹뫝ڕ鈼죠6⪔ћ܍򣭔̨߶_󘵲ܺ졤򞏻址⪹k񚙝󨭯󵬐",
+    ];
+
+    keys.forEach((key) => {
+      expect(cache.get(key)).toBe(undefined);
+      expect(cache.has(key)).toBe(false);
+    });
+  });
+});

--- a/src/workflow/metadata.js
+++ b/src/workflow/metadata.js
@@ -12,7 +12,7 @@ const generateMetadata = async (
   metaPath
 ) => {
   let metaName;
-  // reseolve metaPath
+  // resolve metaPath
   if (metaPath) {
     const { dir, base: metaName } = path.parse(metaPath);
     // make directory if the meta directory does not exist

--- a/src/workflow/metadata.js
+++ b/src/workflow/metadata.js
@@ -8,7 +8,8 @@ const generateMetadata = async (
   name,
   description,
   imageFile,
-  videoFile
+  videoFile,
+  metaName
 ) => {
   // validate image
   let imagePath;
@@ -43,12 +44,12 @@ const generateMetadata = async (
   }
 
   // pin image
-  let metaPath, metaName, imageCid, videoCid;
+  let metaPath, imageCid, videoCid;
 
   if (imageFile) {
     const { dir, name: fname } = path.parse(imagePath);
-    metaPath = path.join(dir, `${fname}.meta`);
-    metaName = fname;
+    metaName = metaName ?? fname;
+    metaPath = path.join(dir, `${metaName}.meta`);
 
     imageCid = await pinataClient.pinFile(imagePath, `${fname}.image`, true);
     if (!imageCid) {
@@ -58,8 +59,8 @@ const generateMetadata = async (
 
   if (videoFile) {
     const { dir, name: fname } = path.parse(videoPath);
-    metaPath = metaPath ?? path.join(dir, `${fname}.meta`);
     metaName = metaName ?? fname;
+    metaPath = metaPath ?? path.join(dir, `${metaName}.meta`);
 
     videoCid = await pinataClient.pinFile(videoPath, `${fname}.video`, true);
     if (!videoCid) {

--- a/src/workflow/wfConfig.js
+++ b/src/workflow/wfConfig.js
@@ -17,7 +17,10 @@ const parseConfig = (cfile) => {
     validateFileExists(configFile, 'workflow config');
 
     configJson = require(configFile);
-    validate(configJson, `No workflow configuration was found in configuration file: ${configFile}`);
+    validate(
+      configJson,
+      `No workflow configuration was found in configuration file: ${configFile}`
+    );
 
     // network
     validateSection(configJson, 'network', configFile);
@@ -33,10 +36,16 @@ const parseConfig = (cfile) => {
     validateSection(configJson, 'class', configFile);
     validateElement(configJson, 'class.id', configFile);
     if (configJson.class.metadata?.imageFile) {
-      validateFileExists(path.resolve(configJson.class.metadata.imageFile), 'class.metadata.imageFile');
+      validateFileExists(
+        path.resolve(configJson.class.metadata.imageFile),
+        'class.metadata.imageFile'
+      );
     }
     if (configJson.class.metadata?.videoFile) {
-      validateFileExists(path.resolve(configJson.class.metadata.videoFile), 'class.metadata.videoFile');
+      validateFileExists(
+        path.resolve(configJson.class.metadata.videoFile),
+        'class.metadata.videoFile'
+      );
     }
 
     // instance
@@ -56,9 +65,15 @@ const parseConfig = (cfile) => {
     let filename = path.basename(configJson.instance.data.csvFile, ext);
     filename += ext ? `.final${ext}` : `.final`;
     let outFilename = path.join(outDir, filename);
+    let metaFolderName = 'metadata';
+    let metaFolderPath = path.join(outDir, metaFolderName);
+    configJson.metadataFolder = path.resolve(metaFolderPath);
     configJson.instance.data.outputCsvFile = path.resolve(outFilename);
 
-    validateFileExists(configJson.instance.data.csvFile, 'instance.data.csvFile');
+    validateFileExists(
+      configJson.instance.data.csvFile,
+      'instance.data.csvFile'
+    );
     validateFileAccess(outDir, 'write');
 
     // instance.metadata
@@ -70,9 +85,13 @@ const parseConfig = (cfile) => {
         const imageFolder = parts.join('/');
 
         configJson.instance.metadata.imageFolder = path.resolve(imageFolder);
-        configJson.instance.metadata.imageFileNameTemplate = imageFileNameTemplate;
+        configJson.instance.metadata.imageFileNameTemplate =
+          imageFileNameTemplate;
 
-        validateFileExists(configJson.instance.metadata.imageFolder, 'instance.metadata.imageFile');
+        validateFileExists(
+          configJson.instance.metadata.imageFolder,
+          'instance.metadata.imageFile'
+        );
       }
 
       if (instanceMetadata.videoFile) {
@@ -81,9 +100,13 @@ const parseConfig = (cfile) => {
         const videoFolder = parts.join('/');
 
         configJson.instance.metadata.videoFolder = path.resolve(videoFolder);
-        configJson.instance.metadata.videoFileNameTemplate = videoFileNameTemplate;
+        configJson.instance.metadata.videoFileNameTemplate =
+          videoFileNameTemplate;
 
-        validateFileExists(configJson.instance.metadata.videoFolder, 'instance.metadata.videoFile');
+        validateFileExists(
+          configJson.instance.metadata.videoFolder,
+          'instance.metadata.videoFile'
+        );
       }
 
       validateElement(configJson, 'instance.metadata.name', configFile);

--- a/src/workflow/workflow.js
+++ b/src/workflow/workflow.js
@@ -249,7 +249,7 @@ const pinAndSetImageCid = async (wfConfig) => {
   let context = getContext();
   const { startRecordNo, endRecordNo } = context.data;
   const { dryRun } = context;
-
+  const rowNumber = (zerobasedIdx) => zerobasedIdx + 2;
   const instanceMetadata = wfConfig?.instance?.metadata;
   if (isEmptyObject(instanceMetadata)) return;
 
@@ -290,19 +290,27 @@ const pinAndSetImageCid = async (wfConfig) => {
 
       let imageFile;
       if (imageFileNameTemplate) {
-        const imageFileName = formatFileName(imageFileNameTemplate, i + 2, {
-          header: context.data.header,
-          records: context.data.records[i],
-        });
+        const imageFileName = formatFileName(
+          imageFileNameTemplate,
+          rowNumber(i),
+          {
+            header: context.data.header,
+            records: context.data.records[i],
+          }
+        );
         imageFile = path.join(imageFolder, imageFileName);
       }
 
       let videoFile;
       if (videoFileNameTemplate) {
-        const videoFileName = formatFileName(videoFileNameTemplate, i + 2, {
-          header: context.data.header,
-          records: context.data.records[i],
-        });
+        const videoFileName = formatFileName(
+          videoFileNameTemplate,
+          rowNumber(i),
+          {
+            header: context.data.header,
+            records: context.data.records[i],
+          }
+        );
         videoFile = path.join(videoFolder, videoFileName);
       }
 
@@ -320,12 +328,14 @@ const pinAndSetImageCid = async (wfConfig) => {
         context.data.records[i]
       );
 
+      let metadatName = `row-${rowNumber(i)}`;
       const { metaCid, imageCid, videoCid } = await generateMetadata(
         context.pinataClient,
         instanceName,
         instanceDescription,
         imageFile,
-        videoFile
+        videoFile,
+        metadatName
       );
 
       imageCidColumn.records[i] = imageCid;

--- a/src/workflow/workflow.js
+++ b/src/workflow/workflow.js
@@ -108,11 +108,14 @@ const setClassMetadata = async (wfConfig) => {
         );
       }
     } else {
+      let metadataFolder = wfConfig.metadataFolder;
+      let metadataFile = path.join(metadataFolder, 'class.meta');
       context.class.metaCid = await generateAndSetClassMetadata(
         context.network,
         context.pinataClient,
         context.class.id,
-        metadata
+        metadata,
+        metadataFile
       );
       // update class checkpoint
       if (!dryRun) context.class.checkpoint();
@@ -252,7 +255,6 @@ const pinAndSetImageCid = async (wfConfig) => {
   const rowNumber = (zerobasedIdx) => zerobasedIdx + 2;
   const instanceMetadata = wfConfig?.instance?.metadata;
   if (isEmptyObject(instanceMetadata)) return;
-
   const {
     name,
     description,
@@ -328,14 +330,16 @@ const pinAndSetImageCid = async (wfConfig) => {
         context.data.records[i]
       );
 
-      let metadatName = `row-${rowNumber(i)}`;
+      let metadataName = `row-${rowNumber(i)}.mata`;
+      let metadataFolder = wfConfig.metadataFolder;
+      let metaPath = path.join(metadataFolder, metadataName);
       const { metaCid, imageCid, videoCid } = await generateMetadata(
         context.pinataClient,
         instanceName,
         instanceDescription,
         imageFile,
         videoFile,
-        metadatName
+        metaPath
       );
 
       imageCidColumn.records[i] = imageCid;

--- a/src/workflow/workflow.js
+++ b/src/workflow/workflow.js
@@ -330,7 +330,7 @@ const pinAndSetImageCid = async (wfConfig) => {
         context.data.records[i]
       );
 
-      let metadataName = `row-${rowNumber(i)}.mata`;
+      let metadataName = `row-${rowNumber(i)}.meta`;
       let metadataFolder = wfConfig.metadataFolder;
       let metaPath = path.join(metadataFolder, metadataName);
       const { metaCid, imageCid, videoCid } = await generateMetadata(


### PR DESCRIPTION
1. Adds a cache to read the cid from cache if it is already uploaded to ipfs. This will improve the performance when there are many NFTs with the same media resource.
2. renames the metadata files to be `<row number>.meta` instead of `<image file name>.meta` to solve the issue that the metadata file for NFTs with the same file name gets rewritten,
3. changes it to save the metadata under a metadata subfolder in out directory instead of saving them next to the images in the image directory. 
